### PR TITLE
fix: navbar scroll alignment

### DIFF
--- a/style.css
+++ b/style.css
@@ -12,6 +12,27 @@
   --glass: rgba(255,255,255,0.6);
   font-family: Inter, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial;
 }
+
+/* -----------GLOBAL SCROLL SETTINGS-------------*/
+
+/*Ensures anchor navigation (Navbar links) aligns correctly 
+  and transitions smoothly without being hidden by the fixed header.
+*/
+
+html {
+  /* Provides a smooth gliding effect instead of an instant jump when clicking links */
+  scroll-behavior: smooth;
+}
+
+section[id] {
+  /* OFFSET FOR FIXED HEADER:
+    Because the header is 'position: fixed', it sits on top of the content.
+    This property creates a 100px 'buffer' at the top of every section 
+    so the heading starts exactly below the navbar.
+  */
+  scroll-margin-top: 100px; 
+}
+
 *{box-sizing:border-box}
 html,body{height:100%}
 body{

--- a/style.css
+++ b/style.css
@@ -15,21 +15,11 @@
 
 /* -----------GLOBAL SCROLL SETTINGS-------------*/
 
-/*Ensures anchor navigation (Navbar links) aligns correctly 
-  and transitions smoothly without being hidden by the fixed header.
-*/
-
 html {
-  /* Provides a smooth gliding effect instead of an instant jump when clicking links */
   scroll-behavior: smooth;
 }
 
 section[id] {
-  /* OFFSET FOR FIXED HEADER:
-    Because the header is 'position: fixed', it sits on top of the content.
-    This property creates a 100px 'buffer' at the top of every section 
-    so the heading starts exactly below the navbar.
-  */
   scroll-margin-top: 100px; 
 }
 


### PR DESCRIPTION
**Related Issue:** Closes #1

**Summary**
Resolved the issue where sections scrolled behind the fixed navbar. Added a top offset to ensure section headings are fully visible upon navigation.

**Changes**

- CSS: Added scroll-margin-top: 100px to section[id] to account for header height.

- UX: Enabled scroll-behavior: smooth for better transition between sections.

**Testing**

Verified that clicking "About", "Environment", "Daily Challenge" , "Quiz" and "Facts & News"  correctly aligns the top of each section below the navbar.